### PR TITLE
Make Keybinder optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Documentation is ![available here](http://clay.readthedocs.io/en/latest/).
 - [gmusicapi] (PYPI)
 - [urwid] (PYPI)
 - [PyYAML] (PYPI)
-- [PyGObject] (native)
-- [Keybinder] (native)
+- [PyGObject] (native, optional, used for global X keybinds)
+- [Keybinder] (native, optional, used for global X keybinds)
 - lib[VLC] (native, distributed with VLC player)
 
 # What works
@@ -91,7 +91,9 @@ confusion. So if you get a `Namespace Keybinder not available` warning
 it is probably caused by this. So, for example, on Arch Linux you need
 the `libkeybinder3` package instead.
 
-0. Install Python 3, PyGObject, keybinder and VLC from your package manager.
+1. Install Python 3, and VLC from your package manager.
+2. Optionally, you can install PyGObject, and keybinder plus bindings
+   if you want global X keybinds.
 
 ## Method 1 (PyPi, automatic)
 

--- a/clay/hotkeys.py
+++ b/clay/hotkeys.py
@@ -3,20 +3,20 @@ Hotkeys management.
 Requires "gi" package and "Gtk" & "Keybinder" modules.
 """
 # pylint: disable=broad-except
-import sys
 import threading
+
+from clay.settings import Settings
+from clay.eventhook import EventHook
+from clay.notifications import NotificationArea
 from clay.log import Logger
 
-def report_error(error):
-    Logger.get().error("{0}: {1}".format(error.__class__.__name__, error))
-
-IS_INIT = False
 try:
     # pylint: disable=import-error
     import gi
     gi.require_version('Keybinder', '3.0')  # noqa
     gi.require_version('Gtk', '3.0')  # noqa
     from gi.repository import Keybinder, Gtk
+    IS_INIT = False
     # pylint: enable=import-error
 except ImportError as error:
     report_error(error)
@@ -30,9 +30,9 @@ except Exception as error:
 else:
     IS_INIT = True
 
-from clay.settings import Settings
-from clay.eventhook import EventHook
-from clay.notifications import NotificationArea
+def report_error(error_msg):
+    "Print an error message to the debug screen"
+    Logger.get().error("{0}: {1}".format(error.__class__.__name__, error_msg))
 
 
 class HotkeyManager(object):


### PR DESCRIPTION
This pull request will turn keybinder and GTK into an optional dependency by checking whether X is actually running or not (using the DISPLAY variable). It also clarifies this in the README. 

This is only a partial solution for people wanting to run it in a headless or TTY environment but you still need to have keybinder to run Clay without errors in a graphical environment. Adding a configuration option or a commandline flag should be enough to fully fix it.

Furthermore, this pull request also changes the error handling of the keybinds. First off, it will print to the debug screen to make it easier for users to see. Secondly, it only shows the human readable info as a popup to user and prints the Python output to the debug screen instead. Lastly, also no longer does a blanket Exception but handles import errors and gi repository errors differently. 

I would recommend reraising the Exception but I kept it the same (print error) as to keep the behaviour the same. 