### PR TITLE
Commandline arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ You *should* get the sound working. Also docker will reuse the Clay config file 
 - `<ESC>` or `<CTRL> /` or <CTRL> _ - close most recent notification or popup
 - `<CTRL> x` - exit app
 
+## X keybinds
+**NOTE:** you need to pass the `--with-x-keybinds` flag for these to work
+- `<XF86AudioPlay>` - play/pause the song
+- `<XF86AudioNext>` - play the next song
+- `<XF86AudioPrev>` - play previous song
+
 # Troubleshooting
 
 At some point, the app may fail. Possible reasons are app bugs,

--- a/clay/app.py
+++ b/clay/app.py
@@ -14,6 +14,7 @@ import argparse
 import os
 import urwid
 
+from clay import meta
 from clay.player import Player
 from clay.playbar import PlayBar
 from clay.pages.debug import DebugPage
@@ -25,6 +26,7 @@ from clay.pages.settings import SettingsPage
 from clay.settings import Settings
 from clay.notifications import NotificationArea
 from clay.gp import GP
+
 
 BG = '#222'
 
@@ -392,27 +394,17 @@ class MultilineVersionAction(argparse.Action):
         super(MultilineVersionAction, self).__init__(option_strings, dest, nargs=0, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        parser.exit(message="""Clay {0}
-
-Copyright 2017 (C) {1} and Clay contributors.
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
-This is free software: you are free to change and redistribute it.
-There is NO WARRANTY, to the extent permitted by law.
-""".format(self.version, self.author))
+        parser.exit(message=meta.COPYRIGHT_MESSAGE)
 
 
 if __name__ == '__main__':
-    #pylint: disable-all
-    app_widget = AppWidget()
-
+    # pylint: disable-all
     parser = argparse.ArgumentParser(
-        prog="Clay",
-        description="Awesome standalone command line player for Google Play Music.",
+        prog=meta.APP_NAME,
+        description=meta.DESCRIPTION,
         epilog="This project is neither affiliated nor endorsed by Google.")
 
-    parser.add_argument(
-        "-v", "--version",
-        action=MultilineVersionAction)
+    parser.add_argument("-v", "--version", action=MultilineVersionAction)
 
     parser.add_argument(
         "--with-x-keybinds",
@@ -427,6 +419,8 @@ if __name__ == '__main__':
     if args.with_x_keybinds:
         Player.get().enable_xorg_bindings()
 
+    # Run the actual program
+    app_widget = AppWidget()
     loop = urwid.MainLoop(app_widget, PALETTE)
     app_widget.set_loop(loop)
     loop.screen.set_terminal_properties(256)

--- a/clay/meta.py
+++ b/clay/meta.py
@@ -1,17 +1,27 @@
 """
 Predefined values.
 """
+APP_NAME = 'Clay Player'
+VERSION = '0.6.2'
+AUTHOR = "Andrew Dunai"
+DESCRIPTION = "Awesome standalone command line player for Google Play Music"
+
 try:
     from codename import codename
 except ImportError:
-    codename = None
-
-APP_NAME = 'Clay Player'
-VERSION = '0.6.2'
-if codename is not None:
-    VERSION_WITH_CODENAME = VERSION + '-' + codename(separator='-', id=VERSION)
-else:
     VERSION_WITH_CODENAME = VERSION
+else:
+    VERSION_WITH_CODENAME = VERSION + ' (' + codename(separator=' ', id=VERSION) + ')'
+
+COPYRIGHT_MESSAGE = """{app_name} {version}
+
+Copyright 2017 - {year} (C) {author} and {app_name} contributors.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licences/gpl.html>
+This is free software; you are free to change it and redistribute it.
+There is NO WARRANTY, to the extent permitted by law
+""".format(app_name=APP_NAME, year=2018,
+           version=VERSION_WITH_CODENAME, author=AUTHOR)
+
 USER_AGENT = ' '.join([
     'Mozilla/5.0 (X11; Linux x86_64)'
     'AppleWebKit/537.36 (KHTML, like Gecko)'

--- a/clay/player.py
+++ b/clay/player.py
@@ -161,16 +161,6 @@ class Player(object):
 
         self.media_player.set_equalizer(self.equalizer)
 
-        # Check whether xorg is running
-        if os.environ.get("DISPLAY") is not None:
-            from clay.hotkeys import HotkeyManager
-            hotkey_manager = HotkeyManager.get()
-            hotkey_manager.play_pause += self.play_pause
-            hotkey_manager.next += self.next
-            hotkey_manager.prev += lambda: self.seek_absolute(0)
-        else:
-            self.logger.debug("X11 isn't running so we can't load the global keybinds")
-
         self._create_station_notification = None
         self._is_loading = False
         self.queue = Queue()
@@ -184,6 +174,18 @@ class Player(object):
             cls.instance = Player()
 
         return cls.instance
+
+    def enable_xorg_bindings(self):
+        """Enable the global X bindings using keybinder"""
+        if os.environ.get("DISPLAY") is None:
+            self.logger.debug("X11 isn't running so we can't load the global keybinds")
+            return
+
+        from clay.hotkeys import HotkeyManager
+        hotkey_manager = HotkeyManager.get()
+        hotkey_manager.play_pause += self.play_pause
+        hotkey_manager.next += self.next
+        hotkey_manager.prev += lambda: self.seek_absolute(0)
 
     def broadcast_state(self):
         """


### PR DESCRIPTION
Adds command line flags to Clay and hopefully fully fixes #11 by only creating a GTK window if a user specifically asks for it using a command line flag. It might be a bit nicer to supplement or replace this by an option in a configuration file but this will work make due for now.

It should also make us (more) compliant with the GPLv3 since it adds a copyright notice to the program. But as said before it **should** also be visible somewhere in the Clay TUI. 