### PR TITLE
Added better settings support.

### DIFF
--- a/clay/app.py
+++ b/clay/app.py
@@ -23,7 +23,7 @@ from clay.pages.myplaylists import MyPlaylistsPage
 from clay.pages.playerqueue import QueuePage
 from clay.pages.search import SearchPage
 from clay.pages.settings import SettingsPage
-from clay.settings import Settings
+from clay.settings import settings
 from clay.notifications import NotificationArea
 from clay.gp import GP
 
@@ -185,9 +185,8 @@ class AppWidget(urwid.Frame):
 
         Request user authorization.
         """
-        config = Settings.get_config()
         username, password, device_id, authtoken = [
-            config.get(x)
+            settings.get(x)
             for x
             in ('username', 'password', 'device_id', 'authtoken')
         ]
@@ -247,7 +246,8 @@ class AppWidget(urwid.Frame):
             )
             return
 
-        Settings.set_config(dict(authtoken=GP.get().get_authtoken()))
+        with settings.edit() as config:
+            config['authtoken'] = GP.get().get_authtoken()
 
         self._login_notification.close()
 

--- a/clay/hotkeys.py
+++ b/clay/hotkeys.py
@@ -5,7 +5,7 @@ Requires "gi" package and "Gtk" & "Keybinder" modules.
 # pylint: disable=broad-except
 import threading
 
-from clay.settings import Settings
+from clay.settings import settings
 from clay.eventhook import EventHook
 from clay.notifications import NotificationArea
 from clay.log import Logger
@@ -84,8 +84,7 @@ class HotkeyManager(object):
         """
         Load hotkey config from settings.
         """
-        config = Settings.get_config()
-        hotkeys = config.get('hotkeys', {})
+        hotkeys = settings.get('hotkeys', {})
         for operation, default_key in HotkeyManager.DEFAULT_HOTKEYS.items():
             if operation not in hotkeys or not hotkeys[operation]:
                 hotkeys[operation] = default_key

--- a/clay/pages/settings.py
+++ b/clay/pages/settings.py
@@ -4,7 +4,7 @@ Components for "Settings" page.
 import urwid
 
 from clay.pages.page import AbstractPage
-from clay.settings import Settings
+from clay.settings import settings
 from clay.player import Player
 
 
@@ -128,19 +128,18 @@ class SettingsPage(urwid.Columns, AbstractPage):
 
     def __init__(self, app):
         self.app = app
-        config = Settings.get_config()
         self.username = urwid.Edit(
-            edit_text=config.get('username', '')
+            edit_text=settings.get('username', '')
         )
         self.password = urwid.Edit(
-            mask='*', edit_text=config.get('password', '')
+            mask='*', edit_text=settings.get('password', '')
         )
         self.device_id = urwid.Edit(
-            edit_text=config.get('device_id', '')
+            edit_text=settings.get('device_id', '')
         )
         self.download_tracks = urwid.CheckBox(
             'Download tracks before playback',
-            state=config.get('download_tracks', False)
+            state=settings.get('download_tracks', False)
         )
         self.equalizer = Equalizer()
         super(SettingsPage, self).__init__([urwid.ListBox(urwid.SimpleListWalker([
@@ -168,12 +167,12 @@ class SettingsPage(urwid.Columns, AbstractPage):
         """
         Called when "Save" button is pressed.
         """
-        Settings.set_config(dict(
-            username=self.username.edit_text,
-            password=self.password.edit_text,
-            device_id=self.device_id.edit_text,
-            download_tracks=self.download_tracks.state
-        ))
+        with settings.edit() as config:
+            config['username'] = self.username.edit_text
+            config['password'] = self.password.edit_text
+            config['device_id'] = self.device_id.edit_text
+            config['download_tracks'] = self.download_tracks.state
+
         self.app.set_page('MyLibraryPage')
         self.app.log_in()
 

--- a/clay/player.py
+++ b/clay/player.py
@@ -15,8 +15,9 @@ except ImportError:  # Python 2.x
 from clay import vlc, meta
 from clay.eventhook import EventHook
 from clay.notifications import NotificationArea
-from clay.settings import Settings
+from clay.settings import settings
 from clay.log import Logger
+
 
 class Queue(object):
     """
@@ -346,8 +347,8 @@ class Player(object):
         self.broadcast_state()
         self.track_changed.fire(track)
 
-        if Settings.get_config().get('download_tracks', False):
-            path = Settings.get_cached_file_path(track.store_id + '.mp3')
+        if settings.get('download_tracks', False):
+            path = settings.get_cached_file_path(track.store_id + '.mp3')
             if path is None:
                 self.logger.debug('Track %s not in cache, downloading...', track.store_id)
                 track.get_url(callback=self._download_track)
@@ -368,7 +369,7 @@ class Player(object):
             )
             return
         response = urlopen(url)
-        path = Settings.save_file_to_cache(track.store_id + '.mp3', response.read())
+        path = settings.save_file_to_cache(track.store_id + '.mp3', response.read())
         self._play_ready(path, None, track)
 
     def _play_ready(self, url, error, track):

--- a/clay/settings.py
+++ b/clay/settings.py
@@ -78,6 +78,12 @@ class _Settings(object):
             self._config = yaml.load(settings_file.read())
 
     def _commit_edits(self, config):
+        """
+        Write config to file.
+
+        This method is supposed to be called only
+        from :py:meth:`~._SettingsEditor.__exit__`.
+        """
         self._config.update(config)
         with open(self._config_file_path, 'w') as settings_file:
             settings_file.write(yaml.dump(self._config, default_flow_style=False))

--- a/clay/settings.py
+++ b/clay/settings.py
@@ -1,78 +1,127 @@
 """
 Application settings manager.
 """
+from threading import Lock
 import os
+import copy
 import errno
 import yaml
 
 import appdirs
 
 
-class Settings(object):
+class _SettingsEditor(dict):
+    """
+    Thread-safe settings editor context manager.
+
+    For example see :py:meth:`~._Settings.edit`.
+    """
+    _lock = Lock()
+
+    def __init__(self, original_config, commit_callback):
+        super(_SettingsEditor, self).__init__()
+        _SettingsEditor._lock.acquire()
+        self._commit_callback = commit_callback
+        self.update(copy.deepcopy(original_config))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        _SettingsEditor._lock.release()
+        if exc_tb is None:
+            self._commit_callback(self)
+        else:
+            # TODO: Handle this
+            pass
+
+
+class _Settings(object):
     """
     Settings management class.
     """
-    @classmethod
-    def get_config_filename(cls):
+    def __init__(self):
+        self._config = {}
+
+        self._ensure_directories()
+        self._load_config()
+
+    def _ensure_directories(self):
         """
-        Return full path to config file.
+        Create config dir, config file & cache dir if they do not exist yet.
         """
-        filedir = appdirs.user_config_dir('clay', 'Clay')
+        self._config_dir = appdirs.user_config_dir('clay', 'Clay')
+        self._config_file_path = os.path.join(self._config_dir, 'config.yaml')
 
         try:
-            os.makedirs(filedir)
+            os.makedirs(self._config_dir)
         except OSError as error:
             if error.errno != errno.EEXIST:
                 raise
 
+        self._cache_dir = appdirs.user_cache_dir('clay', 'Clay')
         try:
-            os.makedirs(appdirs.user_cache_dir('clay', 'Clay'))
+            os.makedirs(self._cache_dir)
         except OSError as error:
             if error.errno != errno.EEXIST:
                 raise
 
-        path = os.path.join(filedir, 'config.yaml')
-        if not os.path.exists(path):
-            with open(path, 'w') as settings:
-                settings.write('{}')
-        return path
+        if not os.path.exists(self._config_file_path):
+            with open(self._config_file_path, 'w') as settings_file:
+                settings_file.write('{}')
 
-    @classmethod
-    def get_config(cls):
+    def _load_config(self):
         """
-        Read config dictionary.
+        Read config from file.
         """
-        with open(Settings.get_config_filename(), 'r') as settings:
-            return yaml.load(settings.read())
+        with open(self._config_file_path, 'r') as settings_file:
+            self._config = yaml.load(settings_file.read())
 
-    @classmethod
-    def set_config(cls, new_config):
-        """
-        Write config dictionary.
-        """
-        config = Settings.get_config()
-        config.update(new_config)
-        with open(Settings.get_config_filename(), 'w') as settings:
-            settings.write(yaml.dump(config, default_flow_style=False))
+    def _commit_edits(self, config):
+        self._config.update(config)
+        with open(self._config_file_path, 'w') as settings_file:
+            settings_file.write(yaml.dump(self._config, default_flow_style=False))
 
-    @classmethod
-    def get_cached_file_path(cls, filename):
+    def get(self, key, default=None):
+        """
+        Return config value.
+        """
+        return self._config.get(key, default)
+
+    def edit(self):
+        """
+        Return :py:class:`._SettingsEditor` context manager to edit config.
+
+        Settings are saved to file once the returned context manager exists.
+
+        Example usage:
+
+        .. code-block:: python
+
+            from clay.settings import settings
+
+            with settings.edit() as config:
+                config['foo']['bar'] = 'baz'
+        """
+        return _SettingsEditor(self._config, self._commit_edits)
+
+    def get_cached_file_path(self, filename):
         """
         Get full path to cached file.
         """
-        cache_dir = appdirs.user_cache_dir('clay', 'Clay')
-        path = os.path.join(cache_dir, filename)
+        path = os.path.join(self._cache_dir, filename)
         if os.path.exists(path):
             return path
         return None
 
-    @classmethod
-    def save_file_to_cache(cls, filename, content):
+    def save_file_to_cache(self, filename, content):
         """
         Save content into file in cache.
         """
-        cache_dir = appdirs.user_cache_dir('clay', 'Clay')
-        path = os.path.join(cache_dir, filename)
+        path = os.path.join(self._cache_dir, filename)
         with open(path, 'wb') as cachefile:
             cachefile.write(content)
         return path
+
+
+settings = _Settings()  # pylint: disable=invalid-name


### PR DESCRIPTION
From now on the proposed way to work with settings is as follows:

```python
from clay.settings import settings
# Fetch settings
foo = settings.get('foo')
# Change settings
with settings.edit() as config:
    config['foo']['bar'] = 'baz'
```

Context manager helps to avoid unnecessary file writes & also prevents developer of forgetting to "flush" settings.

Also `_Settings.edit()` is thread-safe.