### PR TITLE
Fixed #43: Queue next track fix

### DIFF
--- a/clay/playback/abstract.py
+++ b/clay/playback/abstract.py
@@ -102,7 +102,7 @@ class _Queue(object):
             return self.get_current_track()
 
         self.current_track_index += 1
-        if (self.current_track_index + 1) >= len(self.tracks):
+        if (self.current_track_index) >= len(self.tracks):
             self.current_track_index = 0
 
         return self.get_current_track()


### PR DESCRIPTION
The last track in the queue was never playable due to an arithmetic error. This has the side effect of not playing the second track if only two tracks are in the queue.

Merge after #41.