### PR TITLE
Avoid throwing an exception on tracks without an explicitRating key

### DIFF
--- a/clay/gp.py
+++ b/clay/gp.py
@@ -128,7 +128,7 @@ class Track(object):
             self.artist_art_filename = sha1(
                 self.artist_art_url.encode('utf-8')
             ).hexdigest() + u'.jpg'
-        self.explicit_rating = (int(data['explicitType']))
+        self.explicit_rating = (int(data['explicitType'])) if 'explicitType' in data else 0
 
         if self.rating == 5:
             gp.cached_liked_songs.add_liked_song(self)


### PR DESCRIPTION
Without this patch I get some responses from the server that lack an
explicitRating key, causing an exception to be thrown that results in
these tracks being dropped from the user interface.  This simply checks
to see if the explicitRating key exists before attempting to read it.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>