### PR TITLE
Add mobile_client.get_top_songs() to "Liked Songs"

### DIFF
--- a/clay/gp.py
+++ b/clay/gp.py
@@ -95,6 +95,7 @@ class Track(object):
     SOURCE_STATION = 'station'
     SOURCE_PLAYLIST = 'playlist'
     SOURCE_SEARCH = 'search'
+    SOURCE_TOP = 'top'
 
     def __init__(self, source, data):
         # In playlist items and user uploaded songs the storeIds are missing so
@@ -478,6 +479,10 @@ class LikedSongs(object):
         """
         Add a liked song to the list.
         """
+        for track in self._tracks:
+            if track.store_id == song.store_id:
+                return
+
         self._tracks.insert(0, song)
 
     def remove_liked_song(self, song):
@@ -601,6 +606,10 @@ class _GP(object):
         """
         if self.cached_tracks:
             return self.cached_tracks
+
+        for track in Track.from_data(self.mobile_client.get_top_songs(), Track.SOURCE_TOP, True):
+            pass
+
         data = self.mobile_client.get_all_songs()
         self.cached_tracks = Track.from_data(data, Track.SOURCE_LIBRARY, True)
 


### PR DESCRIPTION
The current list of liked songs is only populated with those that happen
to have been enumerated, leaving out songs that have been marked as
thumbs up but are not in the library or a playlist.  This patch
explicitly walks the list from "get_top_songs()", which contains some of
the songs that have been marked as thumbs up.  The result is that my
liked songs list matches what is shown on my phone.

See https://github.com/simon-weber/gmusicapi/issues/637 for more
information.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>