### PR TITLE
Print a backtrace in the debug log for exceptions

### DIFF
--- a/clay/gp.py
+++ b/clay/gp.py
@@ -23,6 +23,8 @@ from clay.eventhook import EventHook
 from clay.log import logger
 from clay.settings import settings
 
+import traceback
+
 STATION_FETCH_LEN = 50
 
 
@@ -181,9 +183,10 @@ class Track(object):
             return track
         except Exception as error:  # pylint: disable=bare-except
             logger.error(
-                'Failed to parse track data: %s, failing data: %s',
+                'Failed to parse track data: %s, failing data: %s, from %s',
                 repr(error),
-                data
+                data,
+                traceback.format_exc()
             )
             # TODO: Fix this.
             # print('Failed to create track from data.')


### PR DESCRIPTION
Without this I found it really hard to debug any exceptions.  I tried
uncommenting the bits below, but didn't really have any luck as it
messed up my terminal.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>